### PR TITLE
مشخص کردن اندازه آرایه به صورت صریح

### DIFF
--- a/2_parser.go
+++ b/2_parser.go
@@ -874,12 +874,22 @@ mylist = [ 1, "kahroba", 3.14, hello() ]
 پس استراکتی که برای پردازش آرایه ها نیاز داریم فقط یک اسلایس از نود ها هست
 */
 type Array struct {
+	Size  int
 	Nodes []Node
 }
 
 func (p *parser) parseArray() Node {
 	p.next() // از روی براکت باز میپریم
+
+	var size int
+	if p.nextToken.Value == ":" { //  در صورتی که اندازه آرایه مشخص شده باشد آن را مقدار دهی میکنیم
+		size, _ = strconv.Atoi(p.currentToken.Value)
+		p.next() // از روی توکن اندازه آرایه می پریم
+		p.next() // از روی توکن : می پریم
+	}
+
 	ret := Array{
+		Size:  size,
 		Nodes: make([]Node, 0), // اسلایس نود ها را مقدار دهی اولیه میکنیم
 	}
 	/*
@@ -892,6 +902,11 @@ func (p *parser) parseArray() Node {
 			p.next()
 		}
 	}
+
+	if ret.Size == 0 { // در صورتی که اندازه ارایه مقداردهی نشده باشد خودمان آن را محاسبه می کنیم
+		ret.Size = len(ret.Nodes)
+	}
+
 	return ret
 }
 

--- a/3_eval.go
+++ b/3_eval.go
@@ -523,9 +523,9 @@ func (n If) Eval(scope *Scope) any {
 a = [1,5+3,4/3,hello()]
 */
 func (n Array) Eval(scope *Scope) any {
-	ret := []any{}
-	for _, node := range n.Nodes {
-		ret = append(ret, node.Eval(scope))
+	ret := make([]any, n.Size)
+	for i, node := range n.Nodes {
+		ret[i] = node.Eval(scope)
 	}
 	return ret
 }

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,15 @@ everything = [1,"kahroba",0.1]
 nums[0] // 1
 everything[1] // "kahroba"
 ```
+برای آنکه اندازه آرایه را مشخص کنید، اندازه آرایه را با : از مقادیر آرایه جدا کنید
+
+```rust
+array = [5: 1, 2] // [1, 2, nil, nil, nil]
+
+println(array[0]) // output : 1
+println(array[4]) // output : nil
+```
+
 به وسیله فانکشن len میتوانیم طول آرایه را بدست بیاوریم
 ```rust
 a = [1,2,3,4,5]


### PR DESCRIPTION
برای آنکه اندازه آرایه را به صورت صریح مشخص کنید از سینتکس زیر استفاده کنید

```rust 
a = [24: "a", "b"]

println(a[0]) // "a"
println(a[1]) // "b"
println(a[10]) // nill
```