### PR TITLE
Add multiline comment support

### DIFF
--- a/1_lexer.go
+++ b/1_lexer.go
@@ -46,6 +46,7 @@ package main
 import (
 	"bufio"
 	"io"
+	"log"
 	"strings"
 	"unicode"
 )
@@ -255,6 +256,26 @@ func (l *lexer) lex() {
 	l.lex()
 }
 
+func (l *lexer) lexMultiLineComment() {
+	for {
+		str, err := l.reader.ReadString('*')
+		_ = str
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+		nextChar, _, err := l.reader.ReadRune()
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+		if nextChar == '/' {
+			break
+		}
+		l.reader.UnreadRune()
+	}
+}
+
 /*
 این متد وظیفه ساخت یک توکن با نوع و مقدار مورد نظر و اضافه کردن به چنل توکن ها را به عهده دارد
 */
@@ -380,6 +401,10 @@ func (l *lexer) lexSymbol(r rune) {
 	}
 	if doubleCharSymbol == "//" {
 		l.reader.ReadLine()
+		return
+	}
+	if doubleCharSymbol == "/*" {
+		l.lexMultiLineComment()
 		return
 	}
 	if t, ok := symobls[singleCharSymbol]; ok {

--- a/docs/en_readme.md
+++ b/docs/en_readme.md
@@ -25,9 +25,19 @@ $ go build
 
 ## Comments
 
+### Single line comment:
 Like most of languages, you can use // to define your comments, they won't get interpreted:
 ```rust
 // This is my first program in Kahroba programming language, Let's Rock!
+```
+
+### Multiline comment:
+You can also have multiline comments in your code, codes within multiline comment block won't get interpreted:
+```rust
+/*
+ This is my first program in Kahroba programming language,
+ Let's Rock!
+*/
 ```
 
 ## Strings


### PR DESCRIPTION
Now if the lexical analyzer sees the start symbol of a multiline comment (`/*`), it tries to find the ending multiline comment (`*/`), and all codes within that comment block will not be interpreted