### PR TITLE
Add double quote escaping support in strings

### DIFF
--- a/1_lexer.go
+++ b/1_lexer.go
@@ -266,12 +266,21 @@ func (l *lexer) emit(t Type, v string) {
 /*
 این ساده ترین متد ماست
 اگر به یک کوتیشن برخورد کردیم این متد اجرا میشود و ما تا به یک کوتیشن دیگر برسیم به خواندن ادامه میدهیم
-سپس کوتیشن ها را اول و آخر رشته حذف میکنیم و یک توکن از نوع استرینگ به چنل اضافه میکنیم
+اگر کوتیشنی که با آن مواجه میشویم با استفاده از کاراکتر بک اسلش (\) اِسکِیپ شده بود آن کوتیشن را به عنوان کوتیشن
+پایانی رشته در نظر نمی گیریم و خواندن را تاجایی که به اولین کوتیشن اسکیپ نشده برسیم ادامه می دهیم
+سپس کوتیشن ها را از اول و آخر رشته و بک اسلکش های اِسکِیپ کننده کوتیشن ها را حذف میکنیم
+در نهایت یک توکن از نوع استرینگ به چنل اضافه میکنیم
 */
 func (l *lexer) lexString() {
-	str, _ := l.reader.ReadString('"')
-	str = strings.TrimRight(str, `"`)
-	l.emit(STRING, str)
+	finalStr, _ := l.reader.ReadString('"')
+	str := finalStr
+	for strings.HasSuffix(str, "\\\"") {
+		str, _ = l.reader.ReadString('"')
+		finalStr += str
+	}
+	finalStr = strings.TrimRight(finalStr, `"`)
+	finalStr = strings.ReplaceAll(finalStr, "\\\"", "\"")
+	l.emit(STRING, finalStr)
 }
 
 /*

--- a/docs/en_readme.md
+++ b/docs/en_readme.md
@@ -46,6 +46,11 @@ Right side type of an operations automatically changes according to the left sid
 "1" + 1 // 11
 ```
 
+You can escape double quote character within a string:
+```rust
+"Normal text, \"quoted text\"" // Normal text, "quoted text"
+```
+
 ## Variables
 Kahroba is a dynamically typed language (like Python), the interpreter assigns variables a type at runtime based on the variable's value at the time.
 


### PR DESCRIPTION
Now double quotes can be used within strings via escaping :)

For example:
```rust
"There is a \"quoted\" string here!" //  There is a "quoted" string here!
```